### PR TITLE
Fix warnings that are being output

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--warnings

--- a/lib/openapi3_parser.rb
+++ b/lib/openapi3_parser.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/document"
-require "openapi3_parser/source_input/raw"
-require "openapi3_parser/source_input/file"
-require "openapi3_parser/source_input/url"
+Dir.glob(File.join(__dir__, "openapi3_parser", "**", "*.rb")).each do |file|
+  require file
+end
 
 module Openapi3Parser
   # For a variety of inputs this will construct an OpenAPI document. For a

--- a/lib/openapi3_parser/context.rb
+++ b/lib/openapi3_parser/context.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/context/location"
-
 module Openapi3Parser
   # Context is a construct used in both the node factories and the nodes
   # themselves. It is used to represent the data, and the source of it, that

--- a/lib/openapi3_parser/context/location.rb
+++ b/lib/openapi3_parser/context/location.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/context/pointer"
-
 module Openapi3Parser
   class Context
     # Class used to represent a location within an OpenAPI document.

--- a/lib/openapi3_parser/document.rb
+++ b/lib/openapi3_parser/document.rb
@@ -1,14 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/cautious_dig"
-require "openapi3_parser/context"
-require "openapi3_parser/context/pointer"
-require "openapi3_parser/document/reference_register"
-require "openapi3_parser/error"
-require "openapi3_parser/node_factory/openapi"
-require "openapi3_parser/source"
-require "openapi3_parser/validation/error_collection"
-
 require "forwardable"
 
 module Openapi3Parser

--- a/lib/openapi3_parser/document/reference_register.rb
+++ b/lib/openapi3_parser/document/reference_register.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/error"
-
 module Openapi3Parser
   class Document
     class ReferenceRegister

--- a/lib/openapi3_parser/node/array.rb
+++ b/lib/openapi3_parser/node/array.rb
@@ -2,8 +2,6 @@
 
 require "forwardable"
 
-require "openapi3_parser/node/map"
-
 module Openapi3Parser
   module Node
     # An array within a OpenAPI document.

--- a/lib/openapi3_parser/node/object.rb
+++ b/lib/openapi3_parser/node/object.rb
@@ -2,8 +2,6 @@
 
 require "forwardable"
 
-require "openapi3_parser/markdown"
-
 module Openapi3Parser
   module Node
     class Object

--- a/lib/openapi3_parser/node/openapi.rb
+++ b/lib/openapi3_parser/node/openapi.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "openapi3_parser/node/object"
-require "openapi3_parser/node/components"
 
 module Openapi3Parser
   module Node

--- a/lib/openapi3_parser/node_factory/array.rb
+++ b/lib/openapi3_parser/node_factory/array.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/context"
-require "openapi3_parser/node_factory"
-require "openapi3_parser/node_factory/type_checker"
-require "openapi3_parser/node/array"
-require "openapi3_parser/validation/validatable"
-
 module Openapi3Parser
   module NodeFactory
     class Array

--- a/lib/openapi3_parser/node_factory/callback.rb
+++ b/lib/openapi3_parser/node_factory/callback.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/context"
 require "openapi3_parser/node_factory/map"
-require "openapi3_parser/node_factory/path_item"
-require "openapi3_parser/node/callback"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/components.rb
+++ b/lib/openapi3_parser/node_factory/components.rb
@@ -1,20 +1,6 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/components"
 require "openapi3_parser/node_factory/object"
-require "openapi3_parser/node_factory/optional_reference"
-require "openapi3_parser/node_factory/map"
-require "openapi3_parser/node_factory/schema"
-require "openapi3_parser/node_factory/response"
-require "openapi3_parser/node_factory/parameter"
-require "openapi3_parser/node_factory/example"
-require "openapi3_parser/node_factory/request_body"
-require "openapi3_parser/node_factory/header"
-require "openapi3_parser/node_factory/security_scheme"
-require "openapi3_parser/node_factory/link"
-require "openapi3_parser/node_factory/callback"
-require "openapi3_parser/validation/input_validator"
-require "openapi3_parser/validators/component_keys"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/contact.rb
+++ b/lib/openapi3_parser/node_factory/contact.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/contact"
 require "openapi3_parser/node_factory/object"
-require "openapi3_parser/validators/url"
-require "openapi3_parser/validators/email"
 require "openapi3_parser/validation/input_validator"
+require "openapi3_parser/validators/email"
+require "openapi3_parser/validators/url"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/discriminator.rb
+++ b/lib/openapi3_parser/node_factory/discriminator.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/discriminator"
 require "openapi3_parser/node_factory/object"
 
 module Openapi3Parser

--- a/lib/openapi3_parser/node_factory/encoding.rb
+++ b/lib/openapi3_parser/node_factory/encoding.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/encoding"
-require "openapi3_parser/node_factory/map"
 require "openapi3_parser/node_factory/object"
-require "openapi3_parser/node_factory/optional_reference"
-require "openapi3_parser/node_factory/header"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/example.rb
+++ b/lib/openapi3_parser/node_factory/example.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/example"
 require "openapi3_parser/node_factory/object"
-require "openapi3_parser/validators/url"
 require "openapi3_parser/validation/input_validator"
+require "openapi3_parser/validators/url"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/external_documentation.rb
+++ b/lib/openapi3_parser/node_factory/external_documentation.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/external_documentation"
 require "openapi3_parser/node_factory/object"
 require "openapi3_parser/validation/input_validator"
 require "openapi3_parser/validators/url"

--- a/lib/openapi3_parser/node_factory/field.rb
+++ b/lib/openapi3_parser/node_factory/field.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory"
-require "openapi3_parser/node_factory/type_checker"
-require "openapi3_parser/validation/validatable"
-
 module Openapi3Parser
   module NodeFactory
     class Field

--- a/lib/openapi3_parser/node_factory/fields/reference.rb
+++ b/lib/openapi3_parser/node_factory/fields/reference.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
 require "forwardable"
-
-require "openapi3_parser/context"
 require "openapi3_parser/node_factory/field"
-require "openapi3_parser/validators/reference"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/header.rb
+++ b/lib/openapi3_parser/node_factory/header.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/header"
-require "openapi3_parser/node_factory/parameter_like"
 require "openapi3_parser/node_factory/object"
+require "openapi3_parser/node_factory/parameter_like"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/info.rb
+++ b/lib/openapi3_parser/node_factory/info.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/info"
-require "openapi3_parser/node_factory/license"
 require "openapi3_parser/node_factory/contact"
+require "openapi3_parser/node_factory/license"
 require "openapi3_parser/node_factory/object"
 require "openapi3_parser/validation/input_validator"
 require "openapi3_parser/validators/url"
@@ -16,8 +15,8 @@ module Openapi3Parser
       field "termsOfService",
             input_type: String,
             validate: Validation::InputValidator.new(Validators::Url)
-      field "contact", factory: Contact
-      field "license", factory: License
+      field "contact", factory: NodeFactory::Contact
+      field "license", factory: NodeFactory::License
       field "version", input_type: String, required: true
 
       private

--- a/lib/openapi3_parser/node_factory/license.rb
+++ b/lib/openapi3_parser/node_factory/license.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/license"
 require "openapi3_parser/node_factory/object"
-require "openapi3_parser/validators/url"
 require "openapi3_parser/validation/input_validator"
+require "openapi3_parser/validators/url"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/link.rb
+++ b/lib/openapi3_parser/node_factory/link.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/license"
-require "openapi3_parser/node_factory/map"
 require "openapi3_parser/node_factory/object"
-require "openapi3_parser/node_factory/server"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/map.rb
+++ b/lib/openapi3_parser/node_factory/map.rb
@@ -1,13 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/array_sentence"
-require "openapi3_parser/context"
-require "openapi3_parser/node_factory"
-require "openapi3_parser/node_factory/type_checker"
-require "openapi3_parser/node/map"
-require "openapi3_parser/validation/validatable"
-require "openapi3_parser/validators/unexpected_fields"
-
 module Openapi3Parser
   module NodeFactory
     class Map

--- a/lib/openapi3_parser/node_factory/media_type.rb
+++ b/lib/openapi3_parser/node_factory/media_type.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/media_type"
-require "openapi3_parser/node_factory/map"
 require "openapi3_parser/node_factory/object"
-require "openapi3_parser/node_factory/optional_reference"
-require "openapi3_parser/node_factory/schema"
-require "openapi3_parser/node_factory/example"
-require "openapi3_parser/node_factory/encoding"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/oauth_flow.rb
+++ b/lib/openapi3_parser/node_factory/oauth_flow.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/oauth_flow"
 require "openapi3_parser/node_factory/object"
 
 module Openapi3Parser

--- a/lib/openapi3_parser/node_factory/oauth_flows.rb
+++ b/lib/openapi3_parser/node_factory/oauth_flows.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/oauth_flows"
-require "openapi3_parser/node_factory/oauth_flow"
 require "openapi3_parser/node_factory/object"
-require "openapi3_parser/node_factory/optional_reference"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/object.rb
+++ b/lib/openapi3_parser/node_factory/object.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
 require "forwardable"
-
-require "openapi3_parser/context"
 require "openapi3_parser/node_factory/object_factory/dsl"
-require "openapi3_parser/node_factory/object_factory/node_builder"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/object_factory/dsl.rb
+++ b/lib/openapi3_parser/node_factory/object_factory/dsl.rb
@@ -13,7 +13,7 @@ module Openapi3Parser
         end
 
         def field_configs
-          @field_configs || {}
+          @field_configs ||= {}
         end
 
         def allow_extensions
@@ -21,27 +21,32 @@ module Openapi3Parser
         end
 
         def allowed_extensions?
-          @allow_extensions == true
+          if instance_variable_defined?(:@allow_extensions)
+            @allow_extensions == true
+          else
+            false
+          end
         end
 
         def mutually_exclusive(*fields, required: false)
-          @mutually_exclusive ||= []
-          @mutually_exclusive << OpenStruct.new(
+          @mutually_exclusive_fields ||= []
+          @mutually_exclusive_fields << OpenStruct.new(
             fields: fields, required: required
           )
         end
 
         def mutually_exclusive_fields
-          @mutually_exclusive || []
+          @mutually_exclusive_fields ||= []
         end
 
         def validate(*items, &block)
-          @validations = (@validations || []).concat(items)
+          @validations ||= []
+          @validations = @validations.concat(items)
           @validations << block if block
         end
 
         def validations
-          @validations || []
+          @validations ||= []
         end
       end
     end

--- a/lib/openapi3_parser/node_factory/object_factory/dsl.rb
+++ b/lib/openapi3_parser/node_factory/object_factory/dsl.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "ostruct"
-
 require "openapi3_parser/node_factory/object_factory/field_config"
 
 module Openapi3Parser

--- a/lib/openapi3_parser/node_factory/object_factory/field_config.rb
+++ b/lib/openapi3_parser/node_factory/object_factory/field_config.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/error"
-require "openapi3_parser/node_factory/type_checker"
-
 module Openapi3Parser
   module NodeFactory
     module ObjectFactory

--- a/lib/openapi3_parser/node_factory/object_factory/node_builder.rb
+++ b/lib/openapi3_parser/node_factory/object_factory/node_builder.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/type_checker"
-require "openapi3_parser/node_factory/object_factory/validator"
-require "openapi3_parser/node_factory/recursive_pointer"
-
 module Openapi3Parser
   module NodeFactory
     module ObjectFactory

--- a/lib/openapi3_parser/node_factory/object_factory/validator.rb
+++ b/lib/openapi3_parser/node_factory/object_factory/validator.rb
@@ -2,13 +2,6 @@
 
 require "forwardable"
 
-require "openapi3_parser/array_sentence"
-require "openapi3_parser/error"
-require "openapi3_parser/validation/validatable"
-require "openapi3_parser/validators/mutually_exclusive_fields"
-require "openapi3_parser/validators/required_fields"
-require "openapi3_parser/validators/unexpected_fields"
-
 module Openapi3Parser
   module NodeFactory
     module ObjectFactory

--- a/lib/openapi3_parser/node_factory/openapi.rb
+++ b/lib/openapi3_parser/node_factory/openapi.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/openapi"
 require "openapi3_parser/node_factory/object"
 require "openapi3_parser/node_factory/info"
-require "openapi3_parser/node_factory/array"
-require "openapi3_parser/node_factory/server"
 require "openapi3_parser/node_factory/paths"
 require "openapi3_parser/node_factory/components"
-require "openapi3_parser/node_factory/security_requirement"
-require "openapi3_parser/node_factory/tag"
 require "openapi3_parser/node_factory/external_documentation"
 
 module Openapi3Parser

--- a/lib/openapi3_parser/node_factory/operation.rb
+++ b/lib/openapi3_parser/node_factory/operation.rb
@@ -1,18 +1,8 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/operation"
-require "openapi3_parser/node_factory/map"
 require "openapi3_parser/node_factory/object"
-require "openapi3_parser/node_factory/optional_reference"
-require "openapi3_parser/node_factory/array"
 require "openapi3_parser/node_factory/external_documentation"
-require "openapi3_parser/node_factory/parameter"
-require "openapi3_parser/node_factory/request_body"
 require "openapi3_parser/node_factory/responses"
-require "openapi3_parser/node_factory/callback"
-require "openapi3_parser/node_factory/server"
-require "openapi3_parser/node_factory/security_requirement"
-require "openapi3_parser/validators/duplicate_parameters"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/optional_reference.rb
+++ b/lib/openapi3_parser/node_factory/optional_reference.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/reference"
-
 module Openapi3Parser
   module NodeFactory
     class OptionalReference

--- a/lib/openapi3_parser/node_factory/parameter.rb
+++ b/lib/openapi3_parser/node_factory/parameter.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/context"
-require "openapi3_parser/node/parameter"
-require "openapi3_parser/node_factory/parameter_like"
 require "openapi3_parser/node_factory/object"
-require "openapi3_parser/validation/error"
+require "openapi3_parser/node_factory/parameter_like"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/parameter_like.rb
+++ b/lib/openapi3_parser/node_factory/parameter_like.rb
@@ -35,8 +35,3 @@ module Openapi3Parser
 end
 
 # These are in the footer as a cyclic dependency can stop this module loading
-require "openapi3_parser/node_factory/optional_reference"
-require "openapi3_parser/node_factory/map"
-require "openapi3_parser/node_factory/schema"
-require "openapi3_parser/node_factory/example"
-require "openapi3_parser/node_factory/media_type"

--- a/lib/openapi3_parser/node_factory/path_item.rb
+++ b/lib/openapi3_parser/node_factory/path_item.rb
@@ -1,15 +1,6 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/path_item"
-require "openapi3_parser/node_factory/fields/reference"
 require "openapi3_parser/node_factory/object"
-require "openapi3_parser/node_factory/object_factory/node_builder"
-require "openapi3_parser/node_factory/optional_reference"
-require "openapi3_parser/node_factory/array"
-require "openapi3_parser/node_factory/server"
-require "openapi3_parser/node_factory/operation"
-require "openapi3_parser/node_factory/parameter"
-require "openapi3_parser/validators/duplicate_parameters"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/paths.rb
+++ b/lib/openapi3_parser/node_factory/paths.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "openapi3_parser/node_factory/map"
-require "openapi3_parser/node_factory/optional_reference"
-require "openapi3_parser/node_factory/path_item"
-require "openapi3_parser/node/paths"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/reference.rb
+++ b/lib/openapi3_parser/node_factory/reference.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/error"
-require "openapi3_parser/node_factory/fields/reference"
 require "openapi3_parser/node_factory/object"
-require "openapi3_parser/node_factory/recursive_pointer"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/request_body.rb
+++ b/lib/openapi3_parser/node_factory/request_body.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/context"
-require "openapi3_parser/node/request_body"
-require "openapi3_parser/node_factory/map"
 require "openapi3_parser/node_factory/object"
-require "openapi3_parser/node_factory/media_type"
-require "openapi3_parser/validation/error"
-require "openapi3_parser/validators/media_type"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/response.rb
+++ b/lib/openapi3_parser/node_factory/response.rb
@@ -1,16 +1,6 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/context"
-require "openapi3_parser/node/response"
-require "openapi3_parser/node_factory/map"
 require "openapi3_parser/node_factory/object"
-require "openapi3_parser/node_factory/optional_reference"
-require "openapi3_parser/node_factory/header"
-require "openapi3_parser/node_factory/media_type"
-require "openapi3_parser/node_factory/link"
-require "openapi3_parser/validation/input_validator"
-require "openapi3_parser/validators/media_type"
-require "openapi3_parser/validators/component_keys"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/responses.rb
+++ b/lib/openapi3_parser/node_factory/responses.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/context"
 require "openapi3_parser/node_factory/map"
-require "openapi3_parser/node_factory/response"
-require "openapi3_parser/node_factory/optional_reference"
-require "openapi3_parser/node/responses"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/schema.rb
+++ b/lib/openapi3_parser/node_factory/schema.rb
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/schema"
-require "openapi3_parser/node_factory/map"
 require "openapi3_parser/node_factory/object"
-require "openapi3_parser/node_factory/optional_reference"
-require "openapi3_parser/node_factory/array"
-require "openapi3_parser/node_factory/external_documentation"
-require "openapi3_parser/node_factory/discriminator"
-require "openapi3_parser/node_factory/xml"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/security_requirement.rb
+++ b/lib/openapi3_parser/node_factory/security_requirement.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/security_requirement"
-require "openapi3_parser/node_factory/array"
 require "openapi3_parser/node_factory/map"
 
 module Openapi3Parser

--- a/lib/openapi3_parser/node_factory/security_scheme.rb
+++ b/lib/openapi3_parser/node_factory/security_scheme.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/security_scheme"
-require "openapi3_parser/node_factory/oauth_flows"
 require "openapi3_parser/node_factory/object"
-require "openapi3_parser/node_factory/optional_reference"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/server.rb
+++ b/lib/openapi3_parser/node_factory/server.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/server"
-require "openapi3_parser/node_factory/map"
 require "openapi3_parser/node_factory/object"
-require "openapi3_parser/node_factory/server_variable"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/server_variable.rb
+++ b/lib/openapi3_parser/node_factory/server_variable.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/server_variable"
 require "openapi3_parser/node_factory/object"
-require "openapi3_parser/node_factory/array"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/node_factory/tag.rb
+++ b/lib/openapi3_parser/node_factory/tag.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/tag"
 require "openapi3_parser/node_factory/object"
 require "openapi3_parser/node_factory/external_documentation"
 

--- a/lib/openapi3_parser/node_factory/type_checker.rb
+++ b/lib/openapi3_parser/node_factory/type_checker.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/error"
-require "openapi3_parser/node_factory"
-
 module Openapi3Parser
   module NodeFactory
     class TypeChecker

--- a/lib/openapi3_parser/node_factory/xml.rb
+++ b/lib/openapi3_parser/node_factory/xml.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/xml"
 require "openapi3_parser/node_factory/object"
-require "openapi3_parser/validators/absolute_uri"
 require "openapi3_parser/validation/input_validator"
+require "openapi3_parser/validators/absolute_uri"
 
 module Openapi3Parser
   module NodeFactory

--- a/lib/openapi3_parser/source.rb
+++ b/lib/openapi3_parser/source.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/error"
-require "openapi3_parser/source/reference"
-require "openapi3_parser/source/reference_resolver"
-
 module Openapi3Parser
   # Represents a source of data used to produce the OpenAPI document. Documents
   # which do not have any references to external files will only have a single

--- a/lib/openapi3_parser/source/reference.rb
+++ b/lib/openapi3_parser/source/reference.rb
@@ -2,9 +2,6 @@
 
 require "cgi"
 
-require "openapi3_parser/source"
-require "openapi3_parser/validators/reference"
-
 module Openapi3Parser
   class Source
     # An object which represents a reference that can be indicated in a OpenAPI

--- a/lib/openapi3_parser/source/reference_resolver.rb
+++ b/lib/openapi3_parser/source/reference_resolver.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/context"
-require "openapi3_parser/source"
-
 module Openapi3Parser
   class Source
     class ReferenceResolver

--- a/lib/openapi3_parser/source_input.rb
+++ b/lib/openapi3_parser/source_input.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/error"
-
 module Openapi3Parser
   # An abstract class which is used to provide a foundation for classes that
   # represent the different means of input an OpenAPI document can have. It is

--- a/lib/openapi3_parser/source_input/file.rb
+++ b/lib/openapi3_parser/source_input/file.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "openapi3_parser/source_input"
-require "openapi3_parser/source_input/string_parser"
-require "openapi3_parser/source_input/resolve_next"
-require "openapi3_parser/error"
 
 module Openapi3Parser
   class SourceInput

--- a/lib/openapi3_parser/source_input/raw.rb
+++ b/lib/openapi3_parser/source_input/raw.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "openapi3_parser/source_input"
-require "openapi3_parser/source_input/string_parser"
-require "openapi3_parser/source_input/resolve_next"
 
 module Openapi3Parser
   class SourceInput

--- a/lib/openapi3_parser/source_input/resolve_next.rb
+++ b/lib/openapi3_parser/source_input/resolve_next.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/source_input/file"
-require "openapi3_parser/source_input/url"
-
 module Openapi3Parser
   class SourceInput
     class ResolveNext

--- a/lib/openapi3_parser/source_input/url.rb
+++ b/lib/openapi3_parser/source_input/url.rb
@@ -2,9 +2,6 @@
 
 require "open-uri"
 require "openapi3_parser/source_input"
-require "openapi3_parser/source_input/string_parser"
-require "openapi3_parser/source_input/resolve_next"
-require "openapi3_parser/error"
 
 module Openapi3Parser
   class SourceInput

--- a/lib/openapi3_parser/validation/validatable.rb
+++ b/lib/openapi3_parser/validation/validatable.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/validation/error"
-require "openapi3_parser/validation/error_collection"
-
 module Openapi3Parser
   module Validation
     class Validatable

--- a/lib/openapi3_parser/validators/mutually_exclusive_fields.rb
+++ b/lib/openapi3_parser/validators/mutually_exclusive_fields.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "openapi3_parser/array_sentence"
-require "openapi3_parser/error"
 
 module Openapi3Parser
   module Validators

--- a/lib/openapi3_parser/validators/required_fields.rb
+++ b/lib/openapi3_parser/validators/required_fields.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "openapi3_parser/array_sentence"
-require "openapi3_parser/error"
 
 module Openapi3Parser
   module Validators

--- a/lib/openapi3_parser/validators/unexpected_fields.rb
+++ b/lib/openapi3_parser/validators/unexpected_fields.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "openapi3_parser/array_sentence"
-require "openapi3_parser/error"
 
 module Openapi3Parser
   module Validators

--- a/openapi3_parser.gemspec
+++ b/openapi3_parser.gemspec
@@ -2,6 +2,7 @@
 
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
 require "openapi3_parser/version"
 
 Gem::Specification.new do |spec|

--- a/spec/integration/open_a_document_with_defaults.rb
+++ b/spec/integration/open_a_document_with_defaults.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "openapi3_parser"
-require "openapi3_parser/error"
-require "openapi3_parser/node/schema"
 
 RSpec.describe "Open a document with recursive references" do
   subject(:document) { Openapi3Parser.load(input) }

--- a/spec/integration/open_a_document_with_recursive_references_spec.rb
+++ b/spec/integration/open_a_document_with_recursive_references_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "openapi3_parser"
-require "openapi3_parser/error"
-require "openapi3_parser/node/schema"
 
 RSpec.describe "Open a document with recursive references" do
   subject(:document) { Openapi3Parser.load(input) }

--- a/spec/integration/open_an_invalid_document_spec.rb
+++ b/spec/integration/open_an_invalid_document_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "openapi3_parser"
-require "openapi3_parser/error"
 
 RSpec.describe "Open an invalid document" do
   subject(:document) { Openapi3Parser.load(input) }

--- a/spec/lib/openapi3_parser/cautious_dig_spec.rb
+++ b/spec/lib/openapi3_parser/cautious_dig_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/cautious_dig"
-
 RSpec.describe Openapi3Parser::CautiousDig do
   describe ".call" do
     subject { described_class.call(collection, *segments) }

--- a/spec/lib/openapi3_parser/context/pointer_spec.rb
+++ b/spec/lib/openapi3_parser/context/pointer_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/context/pointer"
-
 RSpec.describe Openapi3Parser::Context::Pointer do
   describe ".from_fragment" do
     subject { described_class.from_fragment(fragment) }

--- a/spec/lib/openapi3_parser/context_spec.rb
+++ b/spec/lib/openapi3_parser/context_spec.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/context/location"
-require "openapi3_parser/document"
-require "openapi3_parser/node/contact"
-require "openapi3_parser/source_input/raw"
-
 require "support/helpers/context"
 require "support/helpers/source_input"
 

--- a/spec/lib/openapi3_parser/document/reference_register_spec.rb
+++ b/spec/lib/openapi3_parser/document/reference_register_spec.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/context"
-require "openapi3_parser/document/reference_register"
-require "openapi3_parser/error"
-require "openapi3_parser/node_factory/openapi"
-
 require "support/helpers/context"
 
 RSpec.describe Openapi3Parser::Document::ReferenceRegister do

--- a/spec/lib/openapi3_parser/document_spec.rb
+++ b/spec/lib/openapi3_parser/document_spec.rb
@@ -1,14 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/context/pointer"
-require "openapi3_parser/document"
-require "openapi3_parser/node/openapi"
-require "openapi3_parser/node/info"
-require "openapi3_parser/source"
-require "openapi3_parser/source_input/raw"
-require "openapi3_parser/source_input/file"
-require "openapi3_parser/validation/error_collection"
-
 RSpec.describe Openapi3Parser::Document do
   let(:source_input) { Openapi3Parser::SourceInput::Raw.new(source_data) }
 

--- a/spec/lib/openapi3_parser/markdown_spec.rb
+++ b/spec/lib/openapi3_parser/markdown_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/markdown"
-
 RSpec.describe Openapi3Parser::Markdown do
   describe ".to_html" do
     subject { described_class.to_html(text) }

--- a/spec/lib/openapi3_parser/node/object_spec.rb
+++ b/spec/lib/openapi3_parser/node/object_spec.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node/object"
-require "openapi3_parser/node/openapi"
-require "openapi3_parser/node/paths"
-
 require "support/helpers/context"
 
 RSpec.describe Openapi3Parser::Node::Object do

--- a/spec/lib/openapi3_parser/node_factory/array_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/array_spec.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/error"
-require "openapi3_parser/node_factory/array"
-require "openapi3_parser/node_factory/contact"
-require "openapi3_parser/node/array"
-require "openapi3_parser/node/contact"
-
 require "support/helpers/context"
 require "support/node_factory"
 

--- a/spec/lib/openapi3_parser/node_factory/callback_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/callback_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/callback"
-require "openapi3_parser/node/callback"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/components_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/components_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/components"
-require "openapi3_parser/node/components"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/contact_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/contact_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/contact"
-require "openapi3_parser/node/contact"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/discriminator_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/discriminator_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/discriminator"
-require "openapi3_parser/node/discriminator"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/encoding_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/encoding_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/encoding"
-require "openapi3_parser/node/encoding"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/example_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/example_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/example"
-require "openapi3_parser/node/example"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/external_documentation_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/external_documentation_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/external_documentation"
-require "openapi3_parser/node/external_documentation"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/field_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/field_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/error"
-require "openapi3_parser/node_factory/field"
-
 require "support/helpers/context"
 require "support/node_factory"
 

--- a/spec/lib/openapi3_parser/node_factory/fields/reference_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/fields/reference_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/contact"
-require "openapi3_parser/node_factory/fields/reference"
-
 require "support/helpers/context"
 
 RSpec.describe Openapi3Parser::NodeFactory::Fields::Reference do

--- a/spec/lib/openapi3_parser/node_factory/header_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/header_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/header"
-require "openapi3_parser/node/header"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/info_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/info_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/info"
-require "openapi3_parser/node/info"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/license_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/license_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/license"
-require "openapi3_parser/node/license"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/link_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/link_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/link"
-require "openapi3_parser/node/link"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/map_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/map_spec.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/error"
-require "openapi3_parser/node_factory/map"
-require "openapi3_parser/node/map"
-
 require "support/helpers/context"
 require "support/node_factory"
 

--- a/spec/lib/openapi3_parser/node_factory/media_type_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/media_type_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/media_type"
-require "openapi3_parser/node/media_type"
-
 require "support/helpers/context"
 require "support/mutually_exclusive_example"
 require "support/node_object_factory"

--- a/spec/lib/openapi3_parser/node_factory/oauth_flow_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/oauth_flow_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/oauth_flow"
-require "openapi3_parser/node/oauth_flow"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/oauth_flows_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/oauth_flows_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/oauth_flows"
-require "openapi3_parser/node/oauth_flows"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/object_factory/field_config_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/object_factory/field_config_spec.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/error"
-require "openapi3_parser/node_factory/contact"
-require "openapi3_parser/node_factory/object_factory/field_config"
-require "openapi3_parser/validation/validatable"
-
 require "support/helpers/context"
 
 RSpec.describe Openapi3Parser::NodeFactory::ObjectFactory::FieldConfig do

--- a/spec/lib/openapi3_parser/node_factory/object_factory/node_builder_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/object_factory/node_builder_spec.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/error"
-require "openapi3_parser/node_factory/contact"
-require "openapi3_parser/node_factory/object_factory/node_builder"
-require "openapi3_parser/validation/error_collection"
-
 require "support/helpers/context"
 
 RSpec.describe Openapi3Parser::NodeFactory::ObjectFactory::NodeBuilder do

--- a/spec/lib/openapi3_parser/node_factory/object_factory/validator_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/object_factory/validator_spec.rb
@@ -1,12 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/context"
-require "openapi3_parser/error"
-require "openapi3_parser/node_factory/object"
-require "openapi3_parser/node_factory/object_factory/validator"
-require "openapi3_parser/validation/error_collection"
-require "openapi3_parser/validation/error"
-
 require "support/helpers/context"
 
 RSpec.describe Openapi3Parser::NodeFactory::ObjectFactory::Validator do

--- a/spec/lib/openapi3_parser/node_factory/object_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/object_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/error"
-require "openapi3_parser/node_factory/object"
-
 require "support/helpers/context"
 require "support/node_factory"
 

--- a/spec/lib/openapi3_parser/node_factory/openapi_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/openapi_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/openapi"
-require "openapi3_parser/node/openapi"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/operation_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/operation_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/operation"
-require "openapi3_parser/node/operation"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/parameter_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/parameter_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/parameter"
-require "openapi3_parser/node/parameter"
-
 require "support/helpers/context"
 require "support/mutually_exclusive_example"
 require "support/node_object_factory"

--- a/spec/lib/openapi3_parser/node_factory/path_item_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/path_item_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/path_item"
-require "openapi3_parser/node/path_item"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/paths_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/paths_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/paths"
-require "openapi3_parser/node/paths"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/request_body_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/request_body_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/request_body"
-require "openapi3_parser/node/request_body"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/response_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/response_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/response"
-require "openapi3_parser/node/response"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/responses_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/responses_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/responses"
-require "openapi3_parser/node/responses"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/schema_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/schema_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/schema"
-require "openapi3_parser/node/schema"
-
 require "support/default_field"
 require "support/node_object_factory"
 require "support/helpers/context"

--- a/spec/lib/openapi3_parser/node_factory/security_requirement_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/security_requirement_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/security_requirement"
-require "openapi3_parser/node/security_requirement"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/security_scheme_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/security_scheme_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/security_scheme"
-require "openapi3_parser/node/security_scheme"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/server_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/server_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/server"
-require "openapi3_parser/node/server"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/server_variable_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/server_variable_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/server_variable"
-require "openapi3_parser/node/server_variable"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/tag_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/tag_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/tag"
-require "openapi3_parser/node/tag"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/node_factory/type_checker_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/type_checker_spec.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/error"
-require "openapi3_parser/node_factory/type_checker"
-require "openapi3_parser/validation/error"
-require "openapi3_parser/validation/validatable"
-
 require "support/helpers/context"
 
 RSpec.describe Openapi3Parser::NodeFactory::TypeChecker do

--- a/spec/lib/openapi3_parser/node_factory/xml_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/xml_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/node_factory/xml"
-require "openapi3_parser/node/xml"
-
 require "support/node_object_factory"
 require "support/helpers/context"
 

--- a/spec/lib/openapi3_parser/source/reference_spec.rb
+++ b/spec/lib/openapi3_parser/source/reference_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/source/reference"
-
 RSpec.describe Openapi3Parser::Source::Reference do
   describe ".only_fragment?" do
     subject { described_class.new(reference).only_fragment? }

--- a/spec/lib/openapi3_parser/source_input/file_spec.rb
+++ b/spec/lib/openapi3_parser/source_input/file_spec.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/source_input/file"
-require "openapi3_parser/source_input/raw"
-require "openapi3_parser/source_input/url"
-require "openapi3_parser/error"
-require "openapi3_parser/source/reference"
-
 RSpec.describe Openapi3Parser::SourceInput::File do
   let(:valid_input) { "test: this" }
   let(:unparsable_input) { "*invalid: yaml" }

--- a/spec/lib/openapi3_parser/source_input/raw_spec.rb
+++ b/spec/lib/openapi3_parser/source_input/raw_spec.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/source_input/raw"
-require "openapi3_parser/source_input/url"
-require "openapi3_parser/error"
-require "openapi3_parser/source/reference"
-
 RSpec.describe Openapi3Parser::SourceInput::Raw do
   let(:valid_input) { {} }
   let(:unparsable_input) { "*invalid: yaml" }

--- a/spec/lib/openapi3_parser/source_input/resolve_next_spec.rb
+++ b/spec/lib/openapi3_parser/source_input/resolve_next_spec.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/source_input/resolve_next"
-require "openapi3_parser/source_input/file"
-require "openapi3_parser/source_input/raw"
-require "openapi3_parser/source_input/url"
-require "openapi3_parser/source/reference"
-
 RSpec.describe Openapi3Parser::SourceInput::ResolveNext do
   describe "#call" do
     subject do

--- a/spec/lib/openapi3_parser/source_input/string_parser_spec.rb
+++ b/spec/lib/openapi3_parser/source_input/string_parser_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/source_input/string_parser"
-
 RSpec.describe Openapi3Parser::SourceInput::StringParser do
   describe "#call" do
     subject { described_class.call(input, filename) }

--- a/spec/lib/openapi3_parser/source_input/url_spec.rb
+++ b/spec/lib/openapi3_parser/source_input/url_spec.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/source_input/file"
-require "openapi3_parser/source_input/raw"
-require "openapi3_parser/source_input/url"
-require "openapi3_parser/error"
-require "openapi3_parser/source/reference"
-
 RSpec.describe Openapi3Parser::SourceInput::Url do
   let(:valid_input) { "test: this" }
   let(:unparsable_input) { "*invalid: yaml" }

--- a/spec/lib/openapi3_parser/validation/error_collection_spec.rb
+++ b/spec/lib/openapi3_parser/validation/error_collection_spec.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/context/location"
-require "openapi3_parser/document"
-require "openapi3_parser/source_input/raw"
-require "openapi3_parser/validation/error"
-require "openapi3_parser/validation/error_collection"
-
 require "support/helpers/context"
 
 RSpec.describe Openapi3Parser::Validation::ErrorCollection do

--- a/spec/lib/openapi3_parser/validation/error_spec.rb
+++ b/spec/lib/openapi3_parser/validation/error_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/validation/error"
-require "openapi3_parser/validation/error_collection"
-
 require "support/helpers/context"
 
 RSpec.describe Openapi3Parser::Validation::Error do

--- a/spec/lib/openapi3_parser/validators/absolute_uri_spec.rb
+++ b/spec/lib/openapi3_parser/validators/absolute_uri_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/validators/absolute_uri"
-
 RSpec.describe Openapi3Parser::Validators::AbsoluteUri do
   describe ".call" do
     subject { described_class.call(uri) }

--- a/spec/lib/openapi3_parser/validators/component_keys_spec.rb
+++ b/spec/lib/openapi3_parser/validators/component_keys_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/validators/component_keys"
-
 RSpec.describe Openapi3Parser::Validators::ComponentKeys do
   describe ".call" do
     subject { described_class.call(key => {}) }

--- a/spec/lib/openapi3_parser/validators/duplicate_parameters_spec.rb
+++ b/spec/lib/openapi3_parser/validators/duplicate_parameters_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/validators/duplicate_parameters"
-
 RSpec.describe Openapi3Parser::Validators::DuplicateParameters do
   describe ".call" do
     subject { described_class.call(parameters) }

--- a/spec/lib/openapi3_parser/validators/email_spec.rb
+++ b/spec/lib/openapi3_parser/validators/email_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/validators/email"
-
 RSpec.describe Openapi3Parser::Validators::Email do
   describe ".call" do
     subject { described_class.call(email) }

--- a/spec/lib/openapi3_parser/validators/media_type_spec.rb
+++ b/spec/lib/openapi3_parser/validators/media_type_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/validators/media_type"
-
 RSpec.describe Openapi3Parser::Validators::MediaType do
   describe ".call" do
     subject { described_class.call(media_type) }

--- a/spec/lib/openapi3_parser/validators/mutually_exclusive_fields_spec.rb
+++ b/spec/lib/openapi3_parser/validators/mutually_exclusive_fields_spec.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/error"
-require "openapi3_parser/node_factory/object"
-require "openapi3_parser/validation/validatable"
-require "openapi3_parser/validators/mutually_exclusive_fields"
-
 require "support/helpers/context"
 
 RSpec.describe Openapi3Parser::Validators::MutuallyExclusiveFields do

--- a/spec/lib/openapi3_parser/validators/reference_spec.rb
+++ b/spec/lib/openapi3_parser/validators/reference_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/validators/reference"
-
 RSpec.describe Openapi3Parser::Validators::Reference do
   describe "#errors" do
     let(:input) { "#/test" }

--- a/spec/lib/openapi3_parser/validators/required_fields_spec.rb
+++ b/spec/lib/openapi3_parser/validators/required_fields_spec.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/error"
-require "openapi3_parser/node_factory/object"
-require "openapi3_parser/validation/validatable"
-require "openapi3_parser/validators/required_fields"
-
 require "support/helpers/context"
 
 RSpec.describe Openapi3Parser::Validators::RequiredFields do

--- a/spec/lib/openapi3_parser/validators/unexpected_fields_spec.rb
+++ b/spec/lib/openapi3_parser/validators/unexpected_fields_spec.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/error"
-require "openapi3_parser/node_factory/object"
-require "openapi3_parser/validation/validatable"
-require "openapi3_parser/validators/unexpected_fields"
-
 require "support/helpers/context"
 
 RSpec.describe Openapi3Parser::Validators::UnexpectedFields do

--- a/spec/lib/openapi3_parser/validators/url_spec.rb
+++ b/spec/lib/openapi3_parser/validators/url_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/validators/url"
-
 RSpec.describe Openapi3Parser::Validators::Url do
   describe ".call" do
     subject { described_class.call(uri) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,6 @@ require "support/matchers/have_validation_error"
 RSpec.configure do |config|
   config.disable_monkey_patching!
 
-  config.warnings = false
-
   config.order = :random
 
   Kernel.srand config.seed

--- a/spec/support/helpers/context.rb
+++ b/spec/support/helpers/context.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/context"
-require "openapi3_parser/context/location"
-require "openapi3_parser/document"
-require "openapi3_parser/source_input/raw"
-
 module Helpers
   module Context
     # rubocop:disable Metrics/ParameterLists

--- a/spec/support/helpers/source_input.rb
+++ b/spec/support/helpers/source_input.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/source_input/file"
-require "openapi3_parser/source_input/raw"
-require "openapi3_parser/source_input/url"
-
 module Helpers
   module SourceInput
     def create_file_source_input(data: {},

--- a/spec/support/node_factory.rb
+++ b/spec/support/node_factory.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openapi3_parser/validation/error_collection"
-
 RSpec.shared_examples "node factory" do |data_type|
   describe "#node" do
     subject { described_class.new(context) }


### PR DESCRIPTION
This:

- turns on warnings in RSpec, so can see them in the future
- changes the approach to requiring files, to cut out the cyclic dependencies and reduce the number of requires. Now we just require files from outside the library or if we need one loaded in advance of a class
- fix the warnings in the DSL class where we were accessing variables that may not be set

Fixes #6 