### PR TITLE
fix "Unexpected fields" in parameter examples

### DIFF
--- a/lib/openapi3_parser/node_factory/parameter_like.rb
+++ b/lib/openapi3_parser/node_factory/parameter_like.rb
@@ -13,7 +13,7 @@ module Openapi3Parser
       end
 
       def examples_factory(context)
-        factory = NodeFactory::OptionalReference.new(NodeFactory::Schema)
+        factory = NodeFactory::OptionalReference.new(NodeFactory::Example)
         NodeFactory::Map.new(context,
                              default: nil,
                              value_factory: factory)

--- a/spec/lib/openapi3_parser/node_factory/parameter_spec.rb
+++ b/spec/lib/openapi3_parser/node_factory/parameter_spec.rb
@@ -15,7 +15,12 @@ RSpec.describe Openapi3Parser::NodeFactory::Parameter do
           }
         },
         "style" => "form",
-        "explode" => true
+        "explode" => true,
+        "examples" => {
+          "example_name" => {
+            "value" => [1, 2]
+          }
+        }
       }
     end
   end


### PR DESCRIPTION
On path parameters with `examples` the document doesn't validate with `["Unexpected fields: value"]`. This is due to probably a typo in `Openapi3Parser::NodeFactory::ParameterLike#examples_factory`, using `NodeFactory::Schema` instead of `NodeFactory::Example`. This PR fixes that.

Example from an OpenApi3 spec:
```yaml
# openapi.yml
# ...
  '/titles/{title_id}/videos':
    parameters:
      - name: title_id
        in: path
        description: Title ID
        required: true
        schema:
          type: integer
        examples:
          post/201:
            value: 12345
```

This PR fixes `Openapi3Parser.load_file('openapi.yaml').errors` resulting in `["Unexpected fields: value"]`.