### PR TITLE
Add support for commonmarker 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ jobs:
     strategy:
       matrix:
         ruby: [2.6, 2.7, 3.0, 3.1]
+        gemfiles: [Gemfile, gemfiles/commonmarker_low.gemfile, gemfiles/commonmarker_high.gemfile]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -evx
+
+bundle install
+
+# Also install gems for alternate gemfiles
+BUNDLE_GEMFILE=gemfiles/commonmarker_high.gemfile bundle install
+BUNDLE_GEMFILE=gemfiles/commonmarker_low.gemfile bundle install

--- a/bin/verify
+++ b/bin/verify
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# Run ruby tests
+bundle exec rspec
+
+BUNDLE_GEMFILE=gemfiles/commonmarker_high.gemfile bundle exec rspec
+BUNDLE_GEMFILE=gemfiles/commonmarker_low.gemfile bundle exec rspec

--- a/gemfiles/commonmarker_high.gemfile
+++ b/gemfiles/commonmarker_high.gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "commonmarker", "~> 1.1.3"
+
+gemspec path: ".."

--- a/gemfiles/commonmarker_high.gemfile.lock
+++ b/gemfiles/commonmarker_high.gemfile.lock
@@ -1,0 +1,111 @@
+PATH
+  remote: ..
+  specs:
+    openapi3_parser (0.9.2)
+      commonmarker (>= 0.23.6)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
+    ast (2.4.2)
+    bigdecimal (3.1.8)
+    byebug (11.1.3)
+    commonmarker (1.1.3-aarch64-linux)
+    commonmarker (1.1.3-arm64-darwin)
+    commonmarker (1.1.3-x86_64-darwin)
+    commonmarker (1.1.3-x86_64-linux)
+    crack (1.0.0)
+      bigdecimal
+      rexml
+    diff-lcs (1.5.1)
+    docile (1.4.0)
+    hashdiff (1.1.0)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    parallel (1.24.0)
+    parser (3.3.1.0)
+      ast (~> 2.4.1)
+      racc
+    public_suffix (5.0.5)
+    racc (1.8.0)
+    rainbow (3.1.1)
+    rake (13.2.1)
+    regexp_parser (2.9.2)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
+    rubocop (1.63.5)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
+    rubocop-capybara (2.20.0)
+      rubocop (~> 1.41)
+    rubocop-factory_bot (2.25.1)
+      rubocop (~> 1.41)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
+    rubocop-rspec (2.29.2)
+      rubocop (~> 1.40)
+      rubocop-capybara (~> 2.17)
+      rubocop-factory_bot (~> 2.22)
+      rubocop-rspec_rails (~> 2.28)
+    rubocop-rspec_rails (2.28.3)
+      rubocop (~> 1.40)
+    ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
+    strscan (3.1.0)
+    unicode-display_width (2.5.0)
+    webmock (3.23.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+
+PLATFORMS
+  aarch64-linux
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux
+
+DEPENDENCIES
+  bundler
+  byebug (~> 11.0)
+  commonmarker (~> 1.1.3)
+  openapi3_parser!
+  rake
+  rspec (~> 3.9)
+  rubocop (~> 1)
+  rubocop-rake (~> 0.5)
+  rubocop-rspec (~> 2)
+  simplecov (~> 0.19)
+  webmock (~> 3.8)
+
+BUNDLED WITH
+   2.5.3

--- a/gemfiles/commonmarker_low.gemfile
+++ b/gemfiles/commonmarker_low.gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "commonmarker", "= 0.23.6"
+
+gemspec path: ".."

--- a/gemfiles/commonmarker_low.gemfile.lock
+++ b/gemfiles/commonmarker_low.gemfile.lock
@@ -1,0 +1,106 @@
+PATH
+  remote: ..
+  specs:
+    openapi3_parser (0.9.2)
+      commonmarker (>= 0.23.6)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
+    ast (2.4.2)
+    bigdecimal (3.1.8)
+    byebug (11.1.3)
+    commonmarker (0.23.6)
+    crack (1.0.0)
+      bigdecimal
+      rexml
+    diff-lcs (1.5.1)
+    docile (1.4.0)
+    hashdiff (1.1.0)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    parallel (1.24.0)
+    parser (3.3.1.0)
+      ast (~> 2.4.1)
+      racc
+    public_suffix (5.0.5)
+    racc (1.8.0)
+    rainbow (3.1.1)
+    rake (13.2.1)
+    regexp_parser (2.9.2)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
+    rubocop (1.63.5)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
+    rubocop-capybara (2.20.0)
+      rubocop (~> 1.41)
+    rubocop-factory_bot (2.25.1)
+      rubocop (~> 1.41)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
+    rubocop-rspec (2.29.2)
+      rubocop (~> 1.40)
+      rubocop-capybara (~> 2.17)
+      rubocop-factory_bot (~> 2.22)
+      rubocop-rspec_rails (~> 2.28)
+    rubocop-rspec_rails (2.28.3)
+      rubocop (~> 1.40)
+    ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
+    strscan (3.1.0)
+    unicode-display_width (2.5.0)
+    webmock (3.23.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+
+PLATFORMS
+  arm64-darwin-23
+  ruby
+
+DEPENDENCIES
+  bundler
+  byebug (~> 11.0)
+  commonmarker (= 0.23.6)
+  openapi3_parser!
+  rake
+  rspec (~> 3.9)
+  rubocop (~> 1)
+  rubocop-rake (~> 0.5)
+  rubocop-rspec (~> 2)
+  simplecov (~> 0.19)
+  webmock (~> 3.8)
+
+BUNDLED WITH
+   2.5.3

--- a/lib/openapi3_parser/markdown.rb
+++ b/lib/openapi3_parser/markdown.rb
@@ -9,7 +9,11 @@ module Openapi3Parser
     # @param  [String]  text
     # @return [String]
     def self.to_html(text)
-      CommonMarker.render_doc(text).to_html
+      if defined?(CommonMarker)
+        CommonMarker.render_doc(text).to_html
+      else
+        Commonmarker.to_html(text)
+      end
     end
   end
 end

--- a/openapi3_parser.gemspec
+++ b/openapi3_parser.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.6.0"
 
   # Require version than 0.23.6 as earlier versions are susceptible to GHSA-4qw4-jpp4-8gvp
-  spec.add_dependency "commonmarker", "~> 0.23", ">= 0.23.6"
+  spec.add_dependency "commonmarker", ">= 0.23.6"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "byebug", "~> 11.0"


### PR DESCRIPTION
Commonmarker 1.0 was recently released. https://github.com/gjtorikian/commonmarker/releases

This changeset makes it possible to use `openapi3_parser` alongside the latest `commonmarker`.

Given the Commonmarker api changed in the v1 upgrade, I've added logic and additional gemfiles for the CI matrix to ensure backwards compatibility. 

Alternatively, this project could drop support for commonmarker < 1 which would simplify both lib and ci.

### Notes

This will also allow projects to avoid the following warning, which I currently see when using `openapi3_parser` with `commonmarker` `0.23.10`:

```
~/.gem/ruby/3.2.2/gems/commonmarker-0.23.10/lib/commonmarker.rb:44: warning: mismatched indentations at 'end' with 'class' at 15
~/.gem/ruby/3.2.2/gems/commonmarker-0.23.10/lib/commonmarker/config.rb:52: warning: mismatched indentations at 'end' with 'class' at 36
```